### PR TITLE
Refactor(sales invoice.json):Made some sections hidden

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -771,6 +771,7 @@
       "collapsible": 1,
       "fieldname": "sec_tax_breakup",
       "fieldtype": "Section Break",
+      "hidden": 1,
       "label": "Tax Breakup"
     },
     {
@@ -812,6 +813,7 @@
       "collapsible": 1,
       "fieldname": "loyalty_points_redemption",
       "fieldtype": "Section Break",
+      "hidden": 1,
       "label": "Loyalty Points Redemption"
     },
     {
@@ -875,6 +877,7 @@
       "collapsible_depends_on": "discount_amount",
       "fieldname": "section_break_49",
       "fieldtype": "Section Break",
+      "hidden": 1,
       "label": "Additional Discount"
     },
     {
@@ -931,6 +934,7 @@
     {
       "fieldname": "base_rounding_adjustment",
       "fieldtype": "Currency",
+      "hidden": 1,
       "label": "Rounding Adjustment (Company Currency)",
       "no_copy": 1,
       "options": "Company:company:default_currency",
@@ -940,6 +944,7 @@
     {
       "fieldname": "base_rounded_total",
       "fieldtype": "Currency",
+      "hidden": 1,
       "label": "Rounded Total (Company Currency)",
       "oldfieldname": "rounded_total",
       "oldfieldtype": "Currency",
@@ -949,6 +954,7 @@
     },
     {
       "description": "In Words will be visible once you save the Sales Invoice.",
+      "hidden": 1,
       "fieldname": "base_in_words",
       "fieldtype": "Data",
       "label": "In Words (Company Currency)",
@@ -979,6 +985,7 @@
     {
       "fieldname": "rounding_adjustment",
       "fieldtype": "Currency",
+      "hidden": 1,
       "label": "Rounding Adjustment",
       "no_copy": 1,
       "options": "currency",
@@ -989,6 +996,7 @@
       "bold": 1,
       "fieldname": "rounded_total",
       "fieldtype": "Currency",
+      "hidden": 1,
       "label": "Rounded Total",
       "oldfieldname": "rounded_total_export",
       "oldfieldtype": "Currency",
@@ -998,6 +1006,7 @@
     {
       "fieldname": "in_words",
       "fieldtype": "Data",
+      "hidden": 1,
       "label": "In Words",
       "oldfieldname": "in_words_export",
       "oldfieldtype": "Data",
@@ -1180,6 +1189,7 @@
       "depends_on": "grand_total",
       "fieldname": "column_break4",
       "fieldtype": "Section Break",
+      "hidden": 1,
       "label": "Write Off",
       "width": "50%"
     },
@@ -1254,6 +1264,7 @@
       "collapsible": 1,
       "fieldname": "edit_printing_settings",
       "fieldtype": "Section Break",
+      "hidden": 1,
       "label": "Printing Settings"
     },
     {
@@ -1302,6 +1313,7 @@
       "depends_on": "customer",
       "fieldname": "more_information",
       "fieldtype": "Section Break",
+      "hidden": 1,
       "label": "More Information"
     },
     {
@@ -1365,6 +1377,7 @@
       "collapsible": 1,
       "fieldname": "more_info",
       "fieldtype": "Section Break",
+      "hidden": 1,
       "label": "Accounting Details",
       "oldfieldtype": "Section Break",
       "options": "fa fa-file-text",
@@ -1438,6 +1451,7 @@
       "collapsible_depends_on": "sales_partner",
       "fieldname": "sales_team_section_break",
       "fieldtype": "Section Break",
+      "hidden": 1,
       "label": "Commission",
       "oldfieldtype": "Section Break",
       "options": "fa fa-group",
@@ -1481,6 +1495,7 @@
       "collapsible_depends_on": "sales_team",
       "fieldname": "section_break2",
       "fieldtype": "Section Break",
+      "hidden": 1,
       "label": "Sales Team",
       "print_hide": 1
     },
@@ -1497,6 +1512,7 @@
     {
       "fieldname": "subscription_section",
       "fieldtype": "Section Break",
+      "hidden": 1,
       "label": "Subscription Section"
     },
     {


### PR DESCRIPTION
For [issue#4345](https://github.com/elexess/eso-newmatik/issues/4345) and [issue#4344](https://github.com/elexess/eso-newmatik/issues/4344)

Hid these fields:
Tax Breakup
Loyalty Points Redemption
Additional Discount
Rounding Adjustment
Rounded Total
Write Off
Printing Settings
More Information
Accounting Details
Commission
Sales Team
Subscription Section

Screenshot Below:
![screencapture-localhost-8000-desk-2021-07-06-11_28_53](https://user-images.githubusercontent.com/86836253/124537954-6dbec900-de4d-11eb-876a-8c0ebf539969.png)

Problem:
I tried editing the fields in the UI itself but every time I do it it deletes and modifies the entire json file inside the app, that'd be such a pain for the developer to run all those code and check it line by line, so what I did is I hard coded the json file and made the changes there. I was able to make changes to majority of the issue but there is one thing that I cannot modify and that is the base_rounding_adjustment, base_rounded_total and the In Words. I did hide the field and it even shows it in the UI itself that is it hidden but for some reason it is still there.

Screenshot Below:
Base Rounding Adjustment:
![Screenshot from 2021-07-06 11-37-45](https://user-images.githubusercontent.com/86836253/124538784-c9d61d00-de4e-11eb-9312-bc1c23f42a00.png)
Base Rounded Total:
![Screenshot from 2021-07-06 11-38-08](https://user-images.githubusercontent.com/86836253/124538800-d195c180-de4e-11eb-9c3c-a35cee052e41.png)
Problem:
![Screenshot from 2021-07-06 11-40-26](https://user-images.githubusercontent.com/86836253/124538911-099d0480-de4f-11eb-83b8-bdce51490484.png)

Sample Screenshot of the file changes when I edited the field inside the ERPnext UI
![Screenshot from 2021-07-06 11-42-44](https://user-images.githubusercontent.com/86836253/124539117-68fb1480-de4f-11eb-8261-4719e04e5528.png)
![Screenshot from 2021-07-06 11-42-28](https://user-images.githubusercontent.com/86836253/124539132-70bab900-de4f-11eb-8689-18810b983059.png)







