### PR TITLE
Refactor(sales order.json):Made some fields hidden

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -613,6 +613,7 @@
    "collapsible": 1,
    "fieldname": "sec_tax_breakup",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Tax Breakup"
   },
   {
@@ -678,6 +679,7 @@
    "collapsible_depends_on": "discount_amount",
    "fieldname": "section_break_48",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Additional Discount"
   },
   {
@@ -945,6 +947,7 @@
    "collapsible": 1,
    "fieldname": "printing_details",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Printing Details"
   },
   {
@@ -995,6 +998,7 @@
    "collapsible": 1,
    "fieldname": "section_break_78",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Billing and Delivery Status",
    "oldfieldtype": "Column Break",
    "print_hide": 1,
@@ -1073,6 +1077,7 @@
    "collapsible_depends_on": "commission_rate",
    "fieldname": "sales_team_section_break",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Commission",
    "oldfieldtype": "Section Break",
    "options": "fa fa-group",
@@ -1117,6 +1122,7 @@
    "collapsible_depends_on": "sales_team",
    "fieldname": "section_break1",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Sales Team",
    "print_hide": 1
   },
@@ -1134,6 +1140,7 @@
    "allow_on_submit": 1,
    "fieldname": "subscription_section",
    "fieldtype": "Section Break",
+   "hidden": 1,
    "label": "Auto Repeat Section",
    "no_copy": 1,
    "print_hide": 1,
@@ -1194,7 +1201,7 @@
  "icon": "fa fa-file-text",
  "idx": 105,
  "is_submittable": 1,
- "modified": "2019-12-04 03:07:04.055023",
+ "modified": "2021-07-06 06:51:22.309575",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",


### PR DESCRIPTION
For [issue#4343](https://github.com/elexess/eso-newmatik/issues/4343)

Successfully hid all the fields mentioned in the issue#4343
Screenshot:
![screencapture-localhost-8000-desk-2021-07-06-12_07_18](https://user-images.githubusercontent.com/86836253/124540818-c3e23b00-de52-11eb-9a59-77b584143e58.png)

I noticed back when I edited the sales invoice in issue#4345 and issue#4344, it didnt let me edit inside the ERPnext UI but instead it let me edit the json file. Now for the sales order its the contrary, I did exactly the same thing in sale invoice but it didn't let me hard code the json file, instead it allowed me to edit the fields in the ERPnext UI. I just want to bring this up because that's sort of a problem in my opinion.

