### PR TITLE
feat(Hazardous Material): Hazardous Material Features

### DIFF
--- a/erpnext/stock/doctype/control_band/control_band.json
+++ b/erpnext/stock/doctype/control_band/control_band.json
@@ -27,7 +27,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Control",
-   "options": "Elminiation\nSubstitution\nEngineering Controls\nWork Practices\nPPE\nNone",
+   "options": "Elimination\nSubstitution\nEngineering Controls\nWork Practices\nPPE\nNone",
    "translatable": 1
   },
   {
@@ -42,7 +42,7 @@
    "label": "Processing Information"
   }
  ],
- "modified": "2021-07-06 19:36:15.746099",
+ "modified": "2021-09-23 10:05:35.081450",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Control Band",

--- a/erpnext/stock/doctype/ghs_hazard_statement/ghs_hazard_statement.py
+++ b/erpnext/stock/doctype/ghs_hazard_statement/ghs_hazard_statement.py
@@ -3,8 +3,33 @@
 # For license information, please see license.txt
 
 from __future__ import unicode_literals
-# import frappe
+import frappe
 from frappe.model.document import Document
+import collections
+
+from newmatik.custom_hooks.item import on_update
 
 class GHSHazardStatement(Document):
-	pass
+
+	def before_save(self):
+		newlist = frappe.db.get_list("Hazardous Material GHS Precautionary Statements", filters={"parent": self.name})
+		newStr = []	
+		oldStr = []	
+		for x in range(len(newlist)):
+			newS = str(newlist[x]).replace("{","").replace("'","").replace("name: ","").replace("}","")
+			newStr.append(newS)
+		print(newStr)	
+		for i in self.hazardous_material_ghs_precautionary_statements:
+			 oldStr.append(str(i.name))
+		print(oldStr)
+		new = set(newStr)
+		old = set(oldStr)
+		if new != old:
+			doc = frappe.db.get_list("Hazardous Material GHS Hazard Statements", {"ghs_hazard_statement": self.name },"parent")
+			for x in range(len(doc)):
+				s = str(doc[x]).replace("{","").replace("'","").replace("parent: ","").replace("}","")
+				print(s)
+				frappe.db.set_value("Hazardous Material", s, {"status": "Review"})
+		else:
+			pass
+			

--- a/erpnext/stock/doctype/hazardous_material/hazardous_material.py
+++ b/erpnext/stock/doctype/hazardous_material/hazardous_material.py
@@ -3,8 +3,64 @@
 # For license information, please see license.txt
 
 from __future__ import unicode_literals
-# import frappe
+import frappe
 from frappe.model.document import Document
+from datetime import datetime
+
+from six import text_type
 
 class HazardousMaterial(Document):
-	pass
+	
+	def on_change(self):
+		lifecyclelist = frappe.db.get_list("Hazardous Material Company Use", {"parent": self.name }, "lifecycle")
+		newvalue = frappe.db.get_value("Hazardous Material Company Use", {"parent": self.name}, "lifecycle")
+		print(newvalue)
+		if lifecyclelist:
+			lc = lifecyclelist[0]
+			checker = True
+			for x in lifecyclelist:
+				if lc != x:
+					checker = False
+					break
+			if checker == True:
+				print("Same")
+				frappe.db.set_value("Hazardous Material",{"name": self.name}, {"lifecycle": newvalue})
+			else:
+				print("Not Same")
+		else:
+			pass
+
+		decommissioning_date = frappe.db.sql(""" Select max(decommissioning_date) from `tabHazardous Material Company Use` where parent=%s""", self.name)
+		introduction_date = frappe.db.sql(""" Select min(introduction_date) from `tabHazardous Material Company Use` where parent=%s""", self.name)
+		if decommissioning_date == ((None,),):
+			pass
+		else:	
+			d_ds = str(decommissioning_date).replace("((datetime.date(","").replace("),),)","")
+			d_dt = datetime.strptime(d_ds,'%Y, %m, %d')
+			decommission_a = []
+			for d_date in self.hazardous_material_company_use:
+				decommission_a.append(d_date.decommissioning_date)
+			if None in decommission_a:
+				return False
+			else:
+				frappe.db.set_value("Hazardous Material",{"name": self.name}, {"decommissioning_date": d_dt})
+				
+		if introduction_date == ((None,),):
+			pass
+		else:
+			i_ds = str(introduction_date).replace("((datetime.date(","").replace("),),)","")
+			i_dt = datetime.strptime(i_ds,'%Y, %m, %d')
+			introduction_a = []
+			for d_date in self.hazardous_material_company_use:
+				introduction_a.append(d_date.introduction_date)
+			if None in introduction_a:
+				pass
+			else:
+				frappe.db.set_value("Hazardous Material",{"name": self.name}, {"introduction_date": i_dt})
+
+	def save(self, *args, **kwargs):
+		super().save(*args, **kwargs)
+		self.reload()
+
+			
+			


### PR DESCRIPTION
[issue#4769](https://github.com/elexess/eso-newmatik/issues/4769)


### **Hazardous Material Features**

**Item:**

- Added Field "Is Hazardous Material" as is_hazardous_material
- Added Field "Is Personal Protective Equipment (PPE)" as is_ppe

![1](https://user-images.githubusercontent.com/86836253/134605461-ce17fa8a-613a-4afe-b4db-28cf4b8402f4.jpg)

**Filter Item Selection**

- In "Hazardous Material" filter "Item" by item.is_hazardous_material = true

![2_1](https://user-images.githubusercontent.com/86836253/134605525-6ae67301-9be2-45c4-852d-9f609d020fce.gif)

-  In "Control Band" filter "Item" by item.is_ppe = true
![2_2](https://user-images.githubusercontent.com/86836253/134605589-1fa63e51-4ea6-4d0c-9214-1fdca75e0bc4.gif)

**Hazardous Material**

- if "lifecycle" -> "Decommissioned" is selected the Decommissioning Date must be set first.
![3_1](https://user-images.githubusercontent.com/86836253/134605737-702dd7c7-0477-42af-932a-c7f46900870a.gif)

- If "lifecycle" -> "Active use" is selected the Introduction Date must be set first.
![3_2](https://user-images.githubusercontent.com/86836253/134605829-1d8cf5b1-7d68-4d17-b219-164ecc203d1d.gif)

- Make color of "Status" as follows: Draft = red, For Approval = yellow, Approved = green, Review = yellow
![3_3](https://user-images.githubusercontent.com/86836253/134605844-98b45f44-7755-4667-9d86-699b84411d57.gif)

- When adding a "GHS Hazard Statement" in the Child Table -> add all the preset "GHS Precautionary Statements" from the "GHS Hazard Statement" into the "GHS Precautionary Statements" Child Table of the "Hazardous Material".
![3_4](https://user-images.githubusercontent.com/86836253/134605856-e412ec57-beae-4707-bda2-3463dcb60fb8.gif)
 

- If that child table in "GHS Hazard Statement" changes update the Child Table of all "Hazardous Material" which have it in the child table and set the status to "Review".
![3_5](https://user-images.githubusercontent.com/86836253/134605863-7565a4fd-86be-4fa9-9b2d-2ede8ecdda16.gif)

**Hazardous Material Company Use**

-  If one child table entries "Introduction Date" is set overwrite parent "Introduction Date" with the oldest date.
![4_1](https://user-images.githubusercontent.com/86836253/134605947-cb91f7e9-fd9a-43a4-861f-01c9e1106dbb.gif)

-  If all child table entries "Decommissioning Dates" are set overwrite parent "Decomissioning Date" with the newst date.
![4_2](https://user-images.githubusercontent.com/86836253/134605952-0dbef0d9-01a7-4f02-86bb-0095815c36c4.gif)

-  If all child table entries have the same "lifecycle" (not empty) overwrite parent "lifecycle".
![4_3](https://user-images.githubusercontent.com/86836253/134605981-a518a66b-83f5-43e2-a2d2-4367f01005c1.gif)

-  If lifecycle "Decommissioned" is selected the Decommissioning Date must be set first.
![4_4](https://user-images.githubusercontent.com/86836253/134605993-f507c415-dcda-4a36-8689-07fa7c247db0.gif)

-  If "lifecycle" "Active use" is selected the Introduction Date must be set first
![4_5](https://user-images.githubusercontent.com/86836253/134606010-3a2b1d8a-2e86-40cf-86af-5542e70f8d34.gif)

**Print Format**
Task:
   Create a clean Print Format with our current standard style (like CofC, PCB Specification V2).
       - Make sure the pictograms are shown for the GHS Hazard Statements and GHS Precautionary Statements
       - List all Personal Protective Equipment and Processing Information from the linked control bands of the GHS Hazard 
         Statements
![pf](https://user-images.githubusercontent.com/86836253/134606535-7c9f8196-2510-4a44-b165-abb208366843.gif)

Note: This PR is connected to this [PR](https://github.com/elexess/eso-newmatik/pull/4937)