### PR TITLE
refactor(purchase_order_item.json): enabling allow-on-submit for description field

### DIFF
--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -152,6 +152,7 @@
    "label": "Description"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "description",
    "fieldtype": "Text Editor",
    "label": "Description",
@@ -711,7 +712,7 @@
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2020-04-07 18:35:17.558928",
+ "modified": "2021-10-11 10:52:49.631896",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",


### PR DESCRIPTION
[Issue#4942](https://github.com/elexess/eso-newmatik/issues/4942)

Allowing the allow-on-submit for description field in Purchase Order Item 
![PO](https://user-images.githubusercontent.com/40702858/136762390-87d3daeb-f311-4436-b63c-da3f2995f657.gif)


