### PR TITLE
fix(work order): fix logic of fetching qty for SE manufacture type if WO is partially finished

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -992,43 +992,40 @@ class StockEntry(StockController):
 		return item_dict
 
 	def get_unconsumed_raw_materials(self):
+		import math
 		wo = frappe.get_doc("Work Order", self.work_order)
 		wo_items = frappe.get_all('Work Order Item',
 			filters={'parent': self.work_order},
 			fields=["item_code", "required_qty", "consumed_qty"]
 			)
-
+		work_order_qty = wo.qty
 		for item in wo_items:
-			qty = item.required_qty
-
 			item_account_details = get_item_defaults(item.item_code, self.company)
 			# Take into account consumption if there are any.
 			if self.purpose == 'Manufacture':
-				req_qty_each = flt(item.required_qty / wo.qty)
-				if (flt(item.consumed_qty) != 0):
-					remaining_qty = flt(item.consumed_qty) - (flt(wo.produced_qty) * req_qty_each)
-					exhaust_qty = req_qty_each * wo.produced_qty
-					if remaining_qty > exhaust_qty :
-						if (remaining_qty/(req_qty_each * flt(self.fg_completed_qty))) >= 1:
-							qty =0
-						else:
-							qty = (req_qty_each * flt(self.fg_completed_qty)) - remaining_qty
-				else:
-					qty = req_qty_each * flt(self.fg_completed_qty)
+				wo_item_qty = item.transferred_qty or item.required_qty
+				req_qty_each = (
+					((wo_item_qty) - (item.consumed_qty)) /
+                              						((work_order_qty) - (wo.produced_qty))
+				)
 
-			if qty > 0:
-				self.add_to_stock_entry_detail({
-					item.item_code: {
-						"from_warehouse": wo.wip_warehouse,
-						"to_warehouse": "",
-						"qty": qty,
-						"item_name": item.item_name,
-						"description": item.description,
-						"stock_uom": item_account_details.stock_uom,
-						"expense_account": item_account_details.get("expense_account"),
-						"cost_center": item_account_details.get("buying_cost_center"),
-					}
-				})
+				qty = req_qty_each * flt(self.fg_completed_qty)
+
+				qty = math.ceil(qty)
+
+				if qty > 0:
+					self.add_to_stock_entry_detail({
+						item.item_code: {
+							"from_warehouse": wo.wip_warehouse,
+							"to_warehouse": "",
+							"qty": qty,
+							"item_name": item.item_name,
+							"description": item.description,
+							"stock_uom": item_account_details.stock_uom,
+							"expense_account": item_account_details.get("expense_account"),
+							"cost_center": item_account_details.get("buying_cost_center"),
+						}
+					})
 
 	def get_transfered_raw_materials(self):
 		transferred_materials = frappe.db.sql("""


### PR DESCRIPTION
re : https://github.com/elexess/eso-newmatik/issues/5327

Issue:
When declaring "Finish" to a partially created Work Order, the remaining quantities need to create the Work Order are not correctly being fetched. Instead, it double books the quantities required in the stock entry.

Changes:
Fixed the logic for fetching the quantities for the created SE.

![Work order](https://user-images.githubusercontent.com/85614308/154903093-e3a34851-3c7c-4cd8-a5ec-4bce66e7a298.gif)

WO:
![image](https://user-images.githubusercontent.com/85614308/154903167-12b326fa-b50d-4999-92eb-9a0182793615.png)

SE:
![image](https://user-images.githubusercontent.com/85614308/154903338-9feb1c03-20dc-4607-b8a9-f7593cd6ef44.png)




