### PR TITLE
feat: added filter to check if a key exist in dict

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1312,7 +1312,7 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 		user = frappe.session.user
 		if child_item.item_code != d.get("item_code"):
 			if ("Sales Manager" in frappe.get_roles(user)):
-				if (child_item.billed_amt > 0 or child_item.delivered_qty > 0):
+				if (( 'billed_amt' in child_item.__dict__ and child_item.billed_amt > 0 ) or ('delivered_qty' in child_item.__dict__ and child_item.delivered_qty > 0)):
 					frappe.throw(_("Cannot update item since partial bill or partial delivery exists."))
 				else:
 					item_data = frappe.get_doc("Item", d.get("item_code"))


### PR DESCRIPTION
[Issue](https://github.com/elexess/eso-newmatik/issues/5484)

The cause of the error is that in Blanket Order whenever you update an item the object that is being passed doesn't have a 'billed_amt' so with that I added a filter to also check if the object contains a "billed_amt" key.

![Blanket Order](https://user-images.githubusercontent.com/40702858/162434388-98e749c1-d534-4956-90a8-c70a6e49815c.gif)

