### PR TITLE
fix: (bom) hide "switch_to_alternative_item" button if there are no altenative options.

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -561,6 +561,7 @@ cur_frm.select_bomline_alternate_items = function(opts) {
 	cur_frm.set_alt_items = function(){
 		var selected_items = []
 		cur_frm.alt_list_data.forEach(function(item) {
+		if(item.alt_item != parent_item_code)
 		  selected_items.push(
 			  '<a targer="_blank" href="#Form/Item/' + item.alt_item +'">' + item.alt_item + '</a> ' + `(${item.qty})`
 		  )
@@ -631,6 +632,13 @@ cur_frm.select_bomline_alternate_items = function(opts) {
 		},
 		callback:function(r){
 			cur_frm.alt_list_data =  r.message || [];
+			
+
+			var current_item_selection_idx = cur_frm.alt_list_data.findIndex(item => item.alt_item === parent_item_code)
+			if (current_item_selection_idx != -1) {
+				cur_frm.alt_list_data.splice(current_item_selection_idx, 1)
+			}
+
 			cur_frm.render_alts_items(d, headers, cur_frm.alt_list_data)
 			cur_frm.set_alt_items()
 		}

--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -525,7 +525,7 @@ frappe.ui.form.on("BOM Item", "setup_alt_item_btn", function(frm, cdt, cdn) {
 			frm: frm,
 			cdn: cdn,
 			cdt: cdt,
-			item_code: d.item_code,
+			item_code: d.original_item,
 			has_alternatives: d.has_alternatives,
 			bom: d.parent,
 			amended_from: cur_frm.doc.amended_from || null,

--- a/erpnext/manufacturing/doctype/bom/switch_alternative_item.html
+++ b/erpnext/manufacturing/doctype/bom/switch_alternative_item.html
@@ -1,0 +1,27 @@
+<table class="table table-bordered table-hover">
+  <thead class="grid-heading-row">
+    <tr style="text-align: center">
+      {% for (var i = 0; i < header_columns.length; i++) { %}
+      <th style="text-align: center">{{ header_columns[i] }}</th>
+      {% } %}
+    </tr>
+  </thead>
+  <tbody>
+    {% if (data.length)  %}
+    {% for (var i = 0; i < data.length; i++) { %}
+    <tr style="text-align: center" id="data-list-{{i}}">
+      <td>{{ data[i].alt_item }}</td>
+      <td width="30%">{{ data[i].qty }}</td>
+      <td>
+        <button id="data-list-{{i}}" onclick="cur_frm.select_row({{i}})" type="button" class="btn btn-success"><span
+            class="glyphicon glyphicon-check"></button>
+      </td>
+    </tr>
+    {% } %}
+    {% }  else { %}
+    <td style="text-align:center" colspan="6" style="text-align:center;">
+      <br><b class="text-muted">{% __("No Alternative Item")%} </b>
+    </td>
+    {% } %}
+  </tbody>
+</table>


### PR DESCRIPTION
re : https://github.com/elexess/eso-newmatik/issues/5414

remove original bom in alternative bom item options

<img width="862" alt="image" src="https://user-images.githubusercontent.com/85614308/163761792-1d36721b-459d-4041-9783-f357741db2f7.png">
