### PR TITLE
fix(bom): change options for selected_alt_items field when switching bom

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -525,6 +525,7 @@ frappe.ui.form.on("BOM Item", "setup_alt_item_btn", function(frm, cdt, cdn) {
 			frm: frm,
 			cdn: cdn,
 			cdt: cdt,
+			current_item: d.item_code,
 			item_code: d.original_item,
 			has_alternatives: d.has_alternatives,
 			bom: d.parent,
@@ -541,6 +542,7 @@ cur_frm.select_bomline_alternate_items = function(opts) {
 	const bom = opts.bom;
 	const cdn = opts.cdn;
 	const cdt = opts.cdt;
+	const current_item = opts.current_item;
 	const has_alternatives = opts.has_alternatives;
 	const init_qty = opts.init_qty.toFixed(2);
 	const parent_d = opts.parent_d;
@@ -561,7 +563,6 @@ cur_frm.select_bomline_alternate_items = function(opts) {
 	cur_frm.set_alt_items = function(){
 		var selected_items = []
 		cur_frm.alt_list_data.forEach(function(item) {
-		if(item.alt_item != parent_item_code)
 		  selected_items.push(
 			  '<a targer="_blank" href="#Form/Item/' + item.alt_item +'">' + item.alt_item + '</a> ' + `(${item.qty})`
 		  )
@@ -634,10 +635,8 @@ cur_frm.select_bomline_alternate_items = function(opts) {
 			cur_frm.alt_list_data =  r.message || [];
 			
 
-			var current_item_selection_idx = cur_frm.alt_list_data.findIndex(item => item.alt_item === parent_item_code)
-			if (current_item_selection_idx != -1) {
-				cur_frm.alt_list_data.splice(current_item_selection_idx, 1)
-			}
+			var current_item_selection_idx = cur_frm.alt_list_data.findIndex(item => item.alt_item === current_item)
+			cur_frm.alt_list_data.splice(current_item_selection_idx, 1)
 
 			cur_frm.render_alts_items(d, headers, cur_frm.alt_list_data)
 			cur_frm.set_alt_items()


### PR DESCRIPTION
re : https://github.com/elexess/eso-newmatik/issues/5414

Issue: 
the field : selected alternative items are not switching when the alternative bom is switched.

Expected:
the selected alt items should switch to that of the current item being used in the bom line.


Results:
--
![switching](https://user-images.githubusercontent.com/85614308/164369794-25d41741-f35f-41f7-a6ab-1cf25022cd6f.gif)
