### PR TITLE
BOM(fix): Alternative Boms disappearing when setting up alt boms

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -551,7 +551,9 @@ cur_frm.select_bomline_alternate_items = function(opts) {
 	// headers for html rendering
 	var headers = [ __("Alternative Item"),  __("Qty"), __("")]
 	// Global in the scope. Holds the child of child.
-	cur_frm.alt_list_data = [];
+	if(!cur_frm.alt_list_data){
+		cur_frm.alt_list_data = [];
+	}
 	cur_frm.render_alts_items = function(d, headers, data){
 		// render table of BOM Alternative Items
 		d.fields_dict.alt_items.$wrapper.html(
@@ -636,8 +638,9 @@ cur_frm.select_bomline_alternate_items = function(opts) {
 			
 
 			var current_item_selection_idx = cur_frm.alt_list_data.findIndex(item => item.alt_item === current_item)
-			cur_frm.alt_list_data.splice(current_item_selection_idx, 1)
-
+			if (current_item_selection_idx != -1) {
+				cur_frm.alt_list_data.splice(current_item_selection_idx, 1)
+			}
 			cur_frm.render_alts_items(d, headers, cur_frm.alt_list_data)
 			cur_frm.set_alt_items()
 		}


### PR DESCRIPTION
re : https://github.com/elexess/eso-newmatik/issues/5504

Description:
selected bom lines are disappearing when clicking on "setup_alt_item_btn"

Result:
![bom_line_fix](https://user-images.githubusercontent.com/85614308/167080479-2b8d4890-813b-46fc-a085-b8f54c5153c4.gif)

