### PR TITLE
fix(Work Order): fix finish button issue not fetching correct quantities

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1005,6 +1005,7 @@ class StockEntry(StockController):
 			if self.purpose == 'Manufacture':
 				req_qty_each = flt(item.required_qty / wo.qty)
 				if (flt(item.consumed_qty) != 0):
+					
 					remaining_qty = flt(item.consumed_qty) - (flt(wo.produced_qty) * req_qty_each)
 					exhaust_qty = req_qty_each * wo.produced_qty
 					if remaining_qty > exhaust_qty:
@@ -1012,6 +1013,9 @@ class StockEntry(StockController):
 							qty = 0
 						else:
 							qty = (req_qty_each * flt(self.fg_completed_qty)) - remaining_qty
+					else:
+						qty = (req_qty_each * flt(self.fg_completed_qty)) - remaining_qty
+						
 				else:
 					qty = req_qty_each * flt(self.fg_completed_qty)
 


### PR DESCRIPTION
re: https://github.com/elexess/eso-newmatik/issues/5568

Issue: When clicking finish for partially manufactured Work Order, it pull all the required quantities for the Stock Entry. 

Fix: It should only pull the quantities required.

Result:
![Work Order Pulling quantities](https://user-images.githubusercontent.com/85614308/174558263-d307c340-1dad-4bd7-956e-60ca754e36a9.gif)

