### PR TITLE
fix(Sales Order Item): Add Required Date

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2367,6 +2367,7 @@ def set_order_defaults(
 		get_conversion_factor(item.item_code, child_item.uom).get("conversion_factor")
 	)
 	child_item.conversion_factor = flt(trans_item.get("conversion_factor")) or conversion_factor
+	child_item.reqd_by_date = trans_item.get('reqd_by_date') or p_doc.reqd_by_date
 
 	if child_doctype == "Purchase Order Item":
 		# Initialized value will update in parent validation

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -554,9 +554,17 @@ erpnext.utils.update_child_items = function(opts) {
 		fields.splice(3, 0, {
 			fieldtype: 'Float',
 			fieldname: "conversion_factor",
-			in_list_view: 1,
+			in_list_view: 0,
 			label: __("Conversion Factor"),
 			precision: get_precision('conversion_factor')
+		})
+	}
+	if (frm.doc.doctype == 'Sales Order') {
+		fields.splice(2, 0, {
+			fieldtype: 'Date',
+			fieldname: "reqd_by_date",
+			in_list_view: 1,
+			label: __("Reqd By Date")
 		})
 	}
 
@@ -603,6 +611,7 @@ erpnext.utils.update_child_items = function(opts) {
 			"docname": d.name,
 			"name": d.name,
 			"item_code": d.item_code,
+			"reqd_by_date": d.reqd_by_date,
 			"delivery_date": d.delivery_date,
 			"schedule_date": d.schedule_date,
 			"conversion_factor": d.conversion_factor,


### PR DESCRIPTION
Issue:
Error: Sales Order Item Row #4: Value missing for: Reqd By Date

Solution:
In the previous version, we have customized the sales order time and added the required date. Now what happens in the error, it's looking for the required date to pass to the items table. It won't let it pass without the required, as this field is mandatory.

To fix this we have to add a required data field inside the dialog box and pass the data to the items table on update.

Screenshot:
Before:
![SOI_BEFORE](https://user-images.githubusercontent.com/86836253/181497395-fab031c5-35e9-4eb8-bf49-e58ac96bd457.gif)

After:
![SOI_AFTER](https://user-images.githubusercontent.com/86836253/181497414-271e07f7-c676-4423-bad2-607974ff57ee.gif)

