### PR TITLE
refactor(Purchase order item): Allow on Submit Description Field

### DIFF
--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -168,6 +168,7 @@
    "label": "Description"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "description",
    "fieldtype": "Text Editor",
    "label": "Description",
@@ -851,17 +852,15 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-02-02 13:10:18.398976",
+ "modified": "2022-08-02 05:28:15.259533",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",
- "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [],
  "quick_entry": 1,
  "search_fields": "item_name",
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
https://app.asana.com/0/1202487840949165/1202689071891911/f

Issue:
Once a PO is in the status "sent" or "order confirmed" you cannot change the description field anymore. This was a special feature that used to work in the previous ERPNext instance. We need to be able to adjust the description at any time in the PO workflow process.


Solution:
Allow on submit, description field in purchase order item

Before:
![bee](https://user-images.githubusercontent.com/86836253/182287175-5c558931-c882-47a1-a0e5-9b139289b585.jpg)

After:
![aff](https://user-images.githubusercontent.com/86836253/182287191-963bb795-7622-4119-9292-f616c8c35a73.jpg)

