### PR TITLE
feat: commented the validation for zero qty in PO

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2518,13 +2518,16 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 		)
 
 	def validate_quantity(child_item, new_data):
-		if not flt(new_data.get("qty")):
-			frappe.throw(
-				_("Row # {0}: Quantity for Item {1} cannot be zero").format(
-					new_data.get("idx"), frappe.bold(new_data.get("item_code"))
-				),
-				title=_("Invalid Qty"),
-			)
+		""" Commented the validation added in V13 since in our v12 we dont have this validation
+			Also added the blanket order logic from our v12
+		"""
+		# if not flt(new_data.get("qty")):
+		# 	frappe.throw(
+		# 		_("Row # {0}: Quantity for Item {1} cannot be zero").format(
+		# 			new_data.get("idx"), frappe.bold(new_data.get("item_code"))
+		# 		),
+		# 		title=_("Invalid Qty"),
+		# 	)
 
 		if parent_doctype == "Sales Order" and flt(new_data.get("qty")) < flt(child_item.delivered_qty):
 			frappe.throw(_("Cannot set quantity less than delivered quantity"))
@@ -2533,6 +2536,9 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 			child_item.received_qty
 		):
 			frappe.throw(_("Cannot set quantity less than received quantity"))
+
+		if parent_doctype == "Blanket Order" and flt(d.get("qty")) < flt(child_item.ordered_qty):
+			frappe.throw(_("Cannot set quantity less than ordered quantity"))
 
 	def should_update_supplied_items(doc) -> bool:
 		"""Subcontracted PO can allow following changes *after submit*:


### PR DESCRIPTION
Asana Link: https://app.asana.com/0/1202488272591408/1202674240348232

Investigation Result:
As I was checking on this issue I found out that in v13 frappe added a validation to not allow 0 qty. So, I checked our v12 code, we don't have those validations. So before, frappe really don't have these validations they just added it last May 11 you can refer to this commit from frappe https://github.com/frappe/erpnext/commit/56478752e4eb0572ef50a5b713d6b905ba9951b3

Solution:
As discussed in the Asana, we will be commenting out the added validation.

Additional:
As I was checking our v12 coded we're missing condition for blanket order, so I also added it in this PR

![Update Items PO](https://user-images.githubusercontent.com/40702858/182524447-61e67ca0-9b3f-43be-a33d-4b66a09481c2.gif)

