### PR TITLE
(Sales Order): Allow on submit description field

### DIFF
--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -147,6 +147,7 @@
    "label": "Description"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "description",
    "fieldtype": "Text Editor",
    "label": "Description",
@@ -809,15 +810,13 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-04-27 03:15:34.366563",
+ "modified": "2022-08-04 04:16:12.663453",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",
- "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
Asana: https://app.asana.com/0/1202487840949165/1202711935394143/f

Issue: users can't update the Item Description in Sales Orders after submit

Solution: Allow on submit description field

Before:
![so_before](https://user-images.githubusercontent.com/86836253/182751859-2012c90c-b140-49ca-849e-da02bc27842a.jpg)

After:
![so_after](https://user-images.githubusercontent.com/86836253/182751868-0c2a0e11-e561-454b-95cc-04a396891eb1.jpg)

