### PR TITLE
Fix(Work Order):remove v13 function causing alt item qty to update to 1

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -462,32 +462,32 @@ frappe.ui.form.on("Work Order Item", {
 			});
 		}
 	},
+	// function changing the quantity to 1 when using the switch alt item, 
+	// item_code: function(frm, cdt, cdn) {
+	// 	let row = locals[cdt][cdn];
 
-	item_code: function(frm, cdt, cdn) {
-		let row = locals[cdt][cdn];
-
-		if (row.item_code) {
-			frappe.call({
-				method: "erpnext.stock.doctype.item.item.get_item_details",
-				args: {
-					item_code: row.item_code,
-					company: frm.doc.company
-				},
-				callback: function(r) {
-					if (r.message) {
-						frappe.model.set_value(cdt, cdn, {
-							"required_qty": 1,
-							"item_name": r.message.item_name,
-							"description": r.message.description,
-							"source_warehouse": r.message.default_warehouse,
-							"allow_alternative_item": r.message.allow_alternative_item,
-							"include_item_in_manufacturing": r.message.include_item_in_manufacturing
-						});
-					}
-				}
-			});
-		}
-	}
+	// 	if (row.item_code) {
+	// 		frappe.call({
+	// 			method: "erpnext.stock.doctype.item.item.get_item_details",
+	// 			args: {
+	// 				item_code: row.item_code,
+	// 				company: frm.doc.company
+	// 			},
+	// 			callback: function(r) {
+	// 				if (r.message) {
+	// 					frappe.model.set_value(cdt, cdn, {
+	// 						"required_qty": 1,
+	// 						"item_name": r.message.item_name,
+	// 						"description": r.message.description,
+	// 						"source_warehouse": r.message.default_warehouse,
+	// 						"allow_alternative_item": r.message.allow_alternative_item,
+	// 						"include_item_in_manufacturing": r.message.include_item_in_manufacturing
+	// 					});
+	// 				}
+	// 			}
+	// 		});
+	// 	}
+	// }
 });
 
 frappe.ui.form.on("Work Order Item", "switch_to_alt", function(frm, cdt, cdn) {


### PR DESCRIPTION
re : https://app.asana.com/0/1202488269220482/1202714014769535

Issue:
Added function in version-13 updates the quantity to 1. when using the switch item feature, item's required quantity should be the same after switching.


Fix:

![Work Order](https://user-images.githubusercontent.com/85614308/182806314-8ef1bb19-9a5a-4ef3-a121-3579c199ad52.gif)

How to test:
1. Go to work order doctype.
2. Select a work order with alternative items
3. switch item with alternative item


Expected behavior:
required quantity should be the same as original item.
