### PR TITLE
Fix:(Switch Alt item feature)Icon buttons not being displayed

### DIFF
--- a/erpnext/manufacturing/doctype/bom/alternative_items_selector.html
+++ b/erpnext/manufacturing/doctype/bom/alternative_items_selector.html
@@ -20,7 +20,7 @@
                   type="number" step="0.01"/>
         </td>
 				<td>
-            <button id="data-list-{{i}}" onclick="cur_frm.remove_row({{ i }})" type="button" class="btn btn-danger"><span class="glyphicon glyphicon-trash"></button>
+            <button id="data-list-{{i}}" onclick="cur_frm.remove_row({{ i }})" type="button" class="btn btn-danger"><span class="fa fa-trash-o"></button>
         </td>
 			  </tr>
 		  {% } %}

--- a/erpnext/manufacturing/doctype/bom/switch_alternative_item.html
+++ b/erpnext/manufacturing/doctype/bom/switch_alternative_item.html
@@ -14,7 +14,7 @@
       <td width="30%">{{ data[i].qty }}</td>
       <td>
         <button id="data-list-{{i}}" onclick="cur_frm.select_row({{i}})" type="button" class="btn btn-success"><span
-            class="glyphicon glyphicon-check"></button>
+            class="fa fa-check-square-o"></button>
       </td>
     </tr>
     {% } %}

--- a/erpnext/manufacturing/doctype/work_order/alternative_items_selector.html
+++ b/erpnext/manufacturing/doctype/work_order/alternative_items_selector.html
@@ -12,7 +12,7 @@
 			  <tr style="text-align: center" id="data-list-{{i}}">
 				<td>{{ data[i].alt_item }}</td>
 				<td>
-                    <button id="data-list-{{i}}" onclick="cur_frm.select_row({{ i }})" type="button" class="btn btn-success"><span class="glyphicon glyphicon-check"></button>
+                    <button id="data-list-{{i}}" onclick="cur_frm.select_row({{ i }})" type="button" class="btn btn-success"><span class="fa fa-check-square-o"></button>
                 </td>
 			  </tr>
 		  {% } %}


### PR DESCRIPTION
reported via MS teams by @jeremythegreat01 

Issue: Icons in the switch alternative item feature not being displayed

Problem: This is due to migration to version-13. previously frappe version-12 used glyphicons as its icon's library. In version-13 it was changed to font-awesome.

Fix:

BOM Doctype
--
![Screen Shot 2022-08-09 at 3 11 41 PM](https://user-images.githubusercontent.com/85614308/183588366-4e3b7d6b-793d-43da-bd20-28af3c274ed0.png)
![Screen Shot 2022-08-09 at 3 11 26 PM](https://user-images.githubusercontent.com/85614308/183588380-c9063548-cf36-418c-8d78-12f78f81025b.png)
Work Order Doctype
--
![Screen Shot 2022-08-09 at 3 10 23 PM](https://user-images.githubusercontent.com/85614308/183588388-4f0affb7-bdc5-47b6-914f-c1a69c4608ad.png)

