### PR TITLE
Fix(Quotation)Allow on submit payment_term_template and payment sched…

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.json
+++ b/erpnext/selling/doctype/quotation/quotation.json
@@ -118,9 +118,7 @@
   {
    "fieldname": "customer_section",
    "fieldtype": "Section Break",
-   "options": "fa fa-user",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "fa fa-user"
   },
   {
    "allow_on_submit": 1,
@@ -130,9 +128,7 @@
    "hidden": 1,
    "label": "Title",
    "no_copy": 1,
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "fieldname": "naming_series",
@@ -144,9 +140,7 @@
    "options": "SAL-QTN-.YYYY.-",
    "print_hide": 1,
    "reqd": 1,
-   "set_only_once": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "set_only_once": 1
   },
   {
    "default": "Customer",
@@ -158,9 +152,7 @@
    "oldfieldtype": "Select",
    "options": "DocType",
    "print_hide": 1,
-   "reqd": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "reqd": 1
   },
   {
    "bold": 1,
@@ -173,9 +165,7 @@
    "oldfieldtype": "Link",
    "options": "quotation_to",
    "print_hide": 1,
-   "search_index": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "search_index": 1
   },
   {
    "bold": 1,
@@ -184,16 +174,12 @@
    "hidden": 1,
    "in_global_search": 1,
    "label": "Customer Name",
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "fieldname": "column_break1",
    "fieldtype": "Column Break",
    "oldfieldtype": "Column Break",
-   "show_days": 1,
-   "show_seconds": 1,
    "width": "50%"
   },
   {
@@ -207,8 +193,6 @@
    "options": "Quotation",
    "print_hide": 1,
    "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1,
    "width": "150px"
   },
   {
@@ -221,8 +205,6 @@
    "print_hide": 1,
    "remember_last_selected_value": 1,
    "reqd": 1,
-   "show_days": 1,
-   "show_seconds": 1,
    "width": "150px"
   },
   {
@@ -237,16 +219,12 @@
    "oldfieldtype": "Date",
    "reqd": 1,
    "search_index": 1,
-   "show_days": 1,
-   "show_seconds": 1,
    "width": "100px"
   },
   {
    "fieldname": "valid_till",
    "fieldtype": "Date",
-   "label": "Valid Till",
-   "show_days": 1,
-   "show_seconds": 1
+   "label": "Valid Till"
   },
   {
    "default": "Sales",
@@ -258,9 +236,7 @@
    "oldfieldtype": "Select",
    "options": "\nSales\nMaintenance\nShopping Cart",
    "print_hide": 1,
-   "reqd": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "reqd": 1
   },
   {
    "collapsible": 1,
@@ -268,18 +244,14 @@
    "fieldname": "contact_section",
    "fieldtype": "Section Break",
    "label": "Address and Contact",
-   "options": "fa fa-bullhorn",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "fa fa-bullhorn"
   },
   {
    "fieldname": "customer_address",
    "fieldtype": "Link",
    "label": "Customer Address",
    "options": "Address",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "fieldname": "address_display",
@@ -287,9 +259,7 @@
    "label": "Address",
    "oldfieldname": "customer_address",
    "oldfieldtype": "Small Text",
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "fieldname": "contact_person",
@@ -298,26 +268,20 @@
    "oldfieldname": "contact_person",
    "oldfieldtype": "Link",
    "options": "Contact",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "fieldname": "contact_display",
    "fieldtype": "Small Text",
    "in_global_search": 1,
    "label": "Contact",
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "fieldname": "contact_mobile",
    "fieldtype": "Small Text",
    "label": "Mobile No",
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "fieldname": "contact_email",
@@ -326,16 +290,12 @@
    "label": "Contact Email",
    "options": "Email",
    "print_hide": 1,
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "depends_on": "eval:doc.quotation_to=='Customer' && doc.party_name",
    "fieldname": "col_break98",
    "fieldtype": "Column Break",
-   "show_days": 1,
-   "show_seconds": 1,
    "width": "50%"
   },
   {
@@ -343,18 +303,14 @@
    "fieldtype": "Link",
    "label": "Shipping Address",
    "options": "Address",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "fieldname": "shipping_address",
    "fieldtype": "Small Text",
    "label": "Shipping Address",
    "print_hide": 1,
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "depends_on": "eval:doc.quotation_to=='Customer' && doc.party_name",
@@ -365,27 +321,21 @@
    "oldfieldname": "customer_group",
    "oldfieldtype": "Link",
    "options": "Customer Group",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "fieldname": "territory",
    "fieldtype": "Link",
    "label": "Territory",
    "options": "Territory",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "collapsible": 1,
    "fieldname": "currency_and_price_list",
    "fieldtype": "Section Break",
    "label": "Currency and Price List",
-   "options": "fa fa-tag",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "fa fa-tag"
   },
   {
    "fieldname": "currency",
@@ -396,8 +346,6 @@
    "options": "Currency",
    "print_hide": 1,
    "reqd": 1,
-   "show_days": 1,
-   "show_seconds": 1,
    "width": "100px"
   },
   {
@@ -410,15 +358,11 @@
    "precision": "9",
    "print_hide": 1,
    "reqd": 1,
-   "show_days": 1,
-   "show_seconds": 1,
    "width": "100px"
   },
   {
    "fieldname": "column_break2",
    "fieldtype": "Column Break",
-   "show_days": 1,
-   "show_seconds": 1,
    "width": "50%"
   },
   {
@@ -430,8 +374,6 @@
    "options": "Price List",
    "print_hide": 1,
    "reqd": 1,
-   "show_days": 1,
-   "show_seconds": 1,
    "width": "100px"
   },
   {
@@ -441,9 +383,7 @@
    "options": "Currency",
    "print_hide": 1,
    "read_only": 1,
-   "reqd": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "reqd": 1
   },
   {
    "description": "Rate at which Price list currency is converted to company's base currency",
@@ -452,9 +392,7 @@
    "label": "Price List Exchange Rate",
    "precision": "9",
    "print_hide": 1,
-   "reqd": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "reqd": 1
   },
   {
    "default": "0",
@@ -463,17 +401,13 @@
    "label": "Ignore Pricing Rule",
    "no_copy": 1,
    "permlevel": 1,
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "fieldname": "items_section",
    "fieldtype": "Section Break",
    "oldfieldtype": "Section Break",
-   "options": "fa fa-shopping-cart",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "fa fa-shopping-cart"
   },
   {
    "allow_bulk_edit": 1,
@@ -484,39 +418,29 @@
    "oldfieldtype": "Table",
    "options": "Quotation Item",
    "reqd": 1,
-   "show_days": 1,
-   "show_seconds": 1,
    "width": "40px"
   },
   {
    "fieldname": "pricing_rule_details",
    "fieldtype": "Section Break",
-   "label": "Pricing Rules",
-   "show_days": 1,
-   "show_seconds": 1
+   "label": "Pricing Rules"
   },
   {
    "fieldname": "pricing_rules",
    "fieldtype": "Table",
    "label": "Pricing Rule Detail",
    "options": "Pricing Rule Detail",
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "fieldname": "sec_break23",
-   "fieldtype": "Section Break",
-   "show_days": 1,
-   "show_seconds": 1
+   "fieldtype": "Section Break"
   },
   {
    "fieldname": "total_qty",
    "fieldtype": "Float",
    "label": "Total Quantity",
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "fieldname": "base_total",
@@ -524,9 +448,7 @@
    "label": "Total (Company Currency)",
    "options": "Company:company:default_currency",
    "print_hide": 1,
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "fieldname": "base_net_total",
@@ -537,24 +459,18 @@
    "options": "Company:company:default_currency",
    "print_hide": 1,
    "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1,
    "width": "100px"
   },
   {
    "fieldname": "column_break_28",
-   "fieldtype": "Column Break",
-   "show_days": 1,
-   "show_seconds": 1
+   "fieldtype": "Column Break"
   },
   {
    "fieldname": "total",
    "fieldtype": "Currency",
    "label": "Total",
    "options": "currency",
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "fieldname": "net_total",
@@ -562,42 +478,32 @@
    "label": "Net Total",
    "options": "currency",
    "print_hide": 1,
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "fieldname": "total_net_weight",
    "fieldtype": "Float",
    "label": "Total Net Weight",
    "print_hide": 1,
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "fieldname": "taxes_section",
    "fieldtype": "Section Break",
    "label": "Taxes and Charges",
    "oldfieldtype": "Section Break",
-   "options": "fa fa-money",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "fa fa-money"
   },
   {
    "fieldname": "tax_category",
    "fieldtype": "Link",
    "label": "Tax Category",
    "options": "Tax Category",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "fieldname": "column_break_34",
-   "fieldtype": "Column Break",
-   "show_days": 1,
-   "show_seconds": 1
+   "fieldtype": "Column Break"
   },
   {
    "fieldname": "shipping_rule",
@@ -605,15 +511,11 @@
    "label": "Shipping Rule",
    "oldfieldtype": "Button",
    "options": "Shipping Rule",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "fieldname": "section_break_36",
-   "fieldtype": "Section Break",
-   "show_days": 1,
-   "show_seconds": 1
+   "fieldtype": "Section Break"
   },
   {
    "fieldname": "taxes_and_charges",
@@ -622,9 +524,7 @@
    "oldfieldname": "charge",
    "oldfieldtype": "Link",
    "options": "Sales Taxes and Charges Template",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "fieldname": "taxes",
@@ -632,17 +532,13 @@
    "label": "Sales Taxes and Charges",
    "oldfieldname": "other_charges",
    "oldfieldtype": "Table",
-   "options": "Sales Taxes and Charges",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "Sales Taxes and Charges"
   },
   {
    "collapsible": 1,
    "fieldname": "sec_tax_breakup",
    "fieldtype": "Section Break",
-   "label": "Tax Breakup",
-   "show_days": 1,
-   "show_seconds": 1
+   "label": "Tax Breakup"
   },
   {
    "fieldname": "other_charges_calculation",
@@ -651,15 +547,11 @@
    "no_copy": 1,
    "oldfieldtype": "HTML",
    "print_hide": 1,
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "fieldname": "section_break_39",
-   "fieldtype": "Section Break",
-   "show_days": 1,
-   "show_seconds": 1
+   "fieldtype": "Section Break"
   },
   {
    "fieldname": "base_total_taxes_and_charges",
@@ -669,15 +561,11 @@
    "oldfieldtype": "Currency",
    "options": "Company:company:default_currency",
    "print_hide": 1,
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "fieldname": "column_break_42",
-   "fieldtype": "Column Break",
-   "show_days": 1,
-   "show_seconds": 1
+   "fieldtype": "Column Break"
   },
   {
    "fieldname": "total_taxes_and_charges",
@@ -685,34 +573,26 @@
    "label": "Total Taxes and Charges",
    "options": "currency",
    "print_hide": 1,
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "collapsible": 1,
    "collapsible_depends_on": "discount_amount",
    "fieldname": "section_break_44",
    "fieldtype": "Section Break",
-   "label": "Additional Discount and Coupon Code",
-   "show_days": 1,
-   "show_seconds": 1
+   "label": "Additional Discount and Coupon Code"
   },
   {
    "fieldname": "coupon_code",
    "fieldtype": "Link",
    "label": "Coupon Code",
-   "options": "Coupon Code",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "Coupon Code"
   },
   {
    "fieldname": "referral_sales_partner",
    "fieldtype": "Link",
    "label": "Referral Sales Partner",
-   "options": "Sales Partner",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "Sales Partner"
   },
   {
    "default": "Grand Total",
@@ -720,9 +600,7 @@
    "fieldtype": "Select",
    "label": "Apply Additional Discount On",
    "options": "\nGrand Total\nNet Total",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "fieldname": "base_discount_amount",
@@ -730,41 +608,31 @@
    "label": "Additional Discount Amount (Company Currency)",
    "options": "Company:company:default_currency",
    "print_hide": 1,
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "fieldname": "column_break_46",
-   "fieldtype": "Column Break",
-   "show_days": 1,
-   "show_seconds": 1
+   "fieldtype": "Column Break"
   },
   {
    "fieldname": "additional_discount_percentage",
    "fieldtype": "Float",
    "label": "Additional Discount Percentage",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "fieldname": "discount_amount",
    "fieldtype": "Currency",
    "label": "Additional Discount Amount",
    "options": "currency",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "fieldname": "totals",
    "fieldtype": "Section Break",
    "oldfieldtype": "Section Break",
    "options": "fa fa-money",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "fieldname": "base_grand_total",
@@ -775,8 +643,6 @@
    "options": "Company:company:default_currency",
    "print_hide": 1,
    "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1,
    "width": "200px"
   },
   {
@@ -786,9 +652,7 @@
    "no_copy": 1,
    "options": "Company:company:default_currency",
    "print_hide": 1,
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "description": "In Words will be visible once you save the Quotation.",
@@ -800,8 +664,6 @@
    "oldfieldtype": "Data",
    "print_hide": 1,
    "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1,
    "width": "200px"
   },
   {
@@ -813,8 +675,6 @@
    "options": "Company:company:default_currency",
    "print_hide": 1,
    "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1,
    "width": "200px"
   },
   {
@@ -822,8 +682,6 @@
    "fieldtype": "Column Break",
    "oldfieldtype": "Column Break",
    "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1,
    "width": "50%"
   },
   {
@@ -835,8 +693,6 @@
    "oldfieldtype": "Currency",
    "options": "currency",
    "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1,
    "width": "200px"
   },
   {
@@ -846,9 +702,7 @@
    "no_copy": 1,
    "options": "currency",
    "print_hide": 1,
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "bold": 1,
@@ -859,8 +713,6 @@
    "oldfieldtype": "Currency",
    "options": "currency",
    "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1,
    "width": "200px"
   },
   {
@@ -872,35 +724,29 @@
    "oldfieldtype": "Data",
    "print_hide": 1,
    "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1,
    "width": "200px"
   },
   {
    "fieldname": "payment_schedule_section",
    "fieldtype": "Section Break",
-   "label": "Payment Terms",
-   "show_days": 1,
-   "show_seconds": 1
+   "label": "Payment Terms"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "payment_terms_template",
    "fieldtype": "Link",
    "label": "Payment Terms Template",
    "options": "Payment Terms Template",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "payment_schedule",
    "fieldtype": "Table",
    "label": "Payment Schedule",
    "no_copy": 1,
    "options": "Payment Schedule",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "collapsible": 1,
@@ -909,9 +755,7 @@
    "fieldtype": "Section Break",
    "label": "Terms and Conditions",
    "oldfieldtype": "Section Break",
-   "options": "fa fa-legal",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "fa fa-legal"
   },
   {
    "fieldname": "tc_name",
@@ -921,26 +765,20 @@
    "oldfieldtype": "Link",
    "options": "Terms and Conditions",
    "print_hide": 1,
-   "report_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "report_hide": 1
   },
   {
    "fieldname": "terms",
    "fieldtype": "Text Editor",
    "label": "Term Details",
    "oldfieldname": "terms",
-   "oldfieldtype": "Text Editor",
-   "show_days": 1,
-   "show_seconds": 1
+   "oldfieldtype": "Text Editor"
   },
   {
    "collapsible": 1,
    "fieldname": "print_settings",
    "fieldtype": "Section Break",
-   "label": "Print Settings",
-   "show_days": 1,
-   "show_seconds": 1
+   "label": "Print Settings"
   },
   {
    "allow_on_submit": 1,
@@ -950,9 +788,7 @@
    "oldfieldname": "letter_head",
    "oldfieldtype": "Select",
    "options": "Letter Head",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "allow_on_submit": 1,
@@ -960,15 +796,11 @@
    "fieldname": "group_same_items",
    "fieldtype": "Check",
    "label": "Group same items",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "fieldname": "column_break_73",
-   "fieldtype": "Column Break",
-   "show_days": 1,
-   "show_seconds": 1
+   "fieldtype": "Column Break"
   },
   {
    "allow_on_submit": 1,
@@ -980,25 +812,19 @@
    "oldfieldtype": "Link",
    "options": "Print Heading",
    "print_hide": 1,
-   "report_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "report_hide": 1
   },
   {
    "fieldname": "language",
    "fieldtype": "Data",
    "label": "Print Language",
    "print_hide": 1,
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "fieldname": "subscription_section",
    "fieldtype": "Section Break",
-   "label": "Auto Repeat Section",
-   "show_days": 1,
-   "show_seconds": 1
+   "label": "Auto Repeat Section"
   },
   {
    "fieldname": "auto_repeat",
@@ -1007,18 +833,14 @@
    "no_copy": 1,
    "options": "Auto Repeat",
    "print_hide": 1,
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "allow_on_submit": 1,
    "depends_on": "eval: doc.auto_repeat",
    "fieldname": "update_auto_repeat_reference",
    "fieldtype": "Button",
-   "label": "Update Auto Repeat Reference",
-   "show_days": 1,
-   "show_seconds": 1
+   "label": "Update Auto Repeat Reference"
   },
   {
    "collapsible": 1,
@@ -1027,9 +849,7 @@
    "label": "More Information",
    "oldfieldtype": "Section Break",
    "options": "fa fa-file-text",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "fieldname": "campaign",
@@ -1038,9 +858,7 @@
    "oldfieldname": "campaign",
    "oldfieldtype": "Link",
    "options": "Campaign",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "fieldname": "source",
@@ -1049,9 +867,7 @@
    "oldfieldname": "source",
    "oldfieldtype": "Select",
    "options": "Lead Source",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "allow_on_submit": 1,
@@ -1062,17 +878,13 @@
    "no_copy": 1,
    "oldfieldname": "order_lost_reason",
    "oldfieldtype": "Small Text",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "fieldname": "column_break4",
    "fieldtype": "Column Break",
    "oldfieldtype": "Column Break",
    "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1,
    "width": "50%"
   },
   {
@@ -1087,9 +899,7 @@
    "options": "Draft\nOpen\nReplied\nPartially Ordered\nOrdered\nLost\nCancelled\nExpired",
    "print_hide": 1,
    "read_only": 1,
-   "reqd": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "reqd": 1
   },
   {
    "fieldname": "enq_det",
@@ -1099,17 +909,13 @@
    "oldfieldname": "enq_det",
    "oldfieldtype": "Text",
    "print_hide": 1,
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "fieldname": "supplier_quotation",
    "fieldtype": "Link",
    "label": "Supplier Quotation",
-   "options": "Supplier Quotation",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "Supplier Quotation"
   },
   {
    "fieldname": "opportunity",
@@ -1117,9 +923,7 @@
    "label": "Opportunity",
    "options": "Opportunity",
    "print_hide": 1,
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "allow_on_submit": 1,
@@ -1127,9 +931,7 @@
    "fieldtype": "Table MultiSelect",
    "label": "Lost Reasons",
    "options": "Quotation Lost Reason Detail",
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "depends_on": "packed_items",
@@ -1137,9 +939,7 @@
    "fieldtype": "Table",
    "label": "Bundle Items",
    "options": "Packed Item",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "collapsible": 1,
@@ -1149,32 +949,26 @@
    "fieldtype": "Section Break",
    "label": "Bundle Items",
    "options": "fa fa-suitcase",
-   "print_hide": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "print_hide": 1
   },
   {
    "fieldname": "company_address",
    "fieldtype": "Link",
    "label": "Company Address Name",
-   "options": "Address",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "Address"
   },
   {
    "fieldname": "company_address_display",
    "fieldtype": "Small Text",
    "label": "Company Address",
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   }
  ],
  "icon": "fa fa-shopping-cart",
  "idx": 82,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-06-15 20:35:32.635804",
+ "modified": "2022-08-15 06:26:49.134707",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation",


### PR DESCRIPTION
Re: https://app.asana.com/0/1202488269220482/1202720488568726

Issue: compared functionality in version-12 (staging) payment term template and payment schedule is editable even after submit. Changed property is the two fields to be allowed on submit.

![image](https://user-images.githubusercontent.com/85614308/184577224-b841b2b6-6b57-44f9-a44a-1ec9bc8d3977.png)
