### PR TITLE
Fix(Quotation):valid_till date should be editable even after submit

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.json
+++ b/erpnext/selling/doctype/quotation/quotation.json
@@ -222,6 +222,7 @@
    "width": "100px"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "valid_till",
    "fieldtype": "Date",
    "label": "Valid Till"
@@ -968,7 +969,7 @@
  "idx": 82,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-08-15 06:26:49.134707",
+ "modified": "2022-08-16 05:25:15.024242",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation",


### PR DESCRIPTION
re : No asana task. error found will invetigation on quotaiton doctype.

Issue: valid till date is not editable after submit

Fix: Change property of valid_till date "allow on submit" to be true.