### PR TITLE
refactor(Hooks): Remove Core Dunning Function Call

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -400,7 +400,6 @@ doc_events = {
 		"on_submit": [
 			"erpnext.regional.create_transaction_log",
 			"erpnext.accounts.doctype.payment_request.payment_request.update_payment_req_status",
-			"erpnext.accounts.doctype.dunning.dunning.resolve_dunning",
 		],
 		"on_trash": "erpnext.regional.check_deletion_permission",
 	},


### PR DESCRIPTION
Asana Link: https://app.asana.com/0/1202487840949165/1202804825411024/f

Problem:
Es können keine Zahlungen gebucht werden

Solution:
So in version-13 there is an existing python file called dunning, inside here there's a function that we're calling on submit in payment terms that checks the reference sales invoices inside that PT and get the list of all dunning that is link to those sales invoices and set its value to resolved
now what's going on is when it calls that function it sets its status to resolved, and here's where the problem is our dunning doesn't have a field called status that has resolved and unresolved option
when it sets it, it triggers the problem
but for payment terms that doesn't have sales invoice references this works, and we can easily submit.

