### PR TITLE
Fix(accounts_controller)Unable to add item_code using Update item

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2367,7 +2367,9 @@ def set_order_defaults(
 		get_conversion_factor(item.item_code, child_item.uom).get("conversion_factor")
 	)
 	child_item.conversion_factor = flt(trans_item.get("conversion_factor")) or conversion_factor
-	child_item.reqd_by_date = trans_item.get('reqd_by_date') or p_doc.reqd_by_date
+	
+	if parent_doctype == 'Sales Order':
+		child_item.reqd_by_date = trans_item.get('reqd_by_date') or p_doc.reqd_by_date
 
 	if child_doctype == "Purchase Order Item":
 		# Initialized value will update in parent validation


### PR DESCRIPTION
re : https://app.asana.com/0/1202488269220482/1202846633911274/1202768401338209

Issue: unable to add item using update item code because it's looking for req_by_date field. The Req By Date field is only used in Sales Order. Since Purchase Order already has a Request by date field, but it's field name is "schedule_date"


Fix:
--
![Purchase Order Update item](https://user-images.githubusercontent.com/85614308/186341376-83f18473-8e1a-4ded-8712-033a8d2b3e84.gif)


