### PR TITLE
fix(Purchase Invoice): Conversion Rate Cannot be 1|0

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -98,7 +98,7 @@ class PurchaseInvoice(BuyingController):
 			self.make_batches("warehouse")
 
 		self.validate_release_date()
-		self.check_conversion_rate()
+		#self.check_conversion_rate()
 		self.validate_credit_to_acc()
 		self.clear_unallocated_advances("Purchase Invoice Advance", "advances")
 		self.check_on_hold_or_closed_status()

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -116,7 +116,7 @@ class SalesInvoice(SellingController):
 		self.set_income_account_for_fixed_assets()
 		self.validate_item_cost_centers()
 		self.validate_income_account()
-		self.check_conversion_rate()
+		#self.check_conversion_rate()
 
 		validate_inter_company_party(
 			self.doctype, self.customer, self.company, self.inter_company_invoice_reference


### PR DESCRIPTION
Asana: https://app.asana.com/0/1202487840949165/1202960961234555/f
Issue:
Tanja could not create a purchase invoice for purchase order [PO-DE-22-02155](https://erp.eso-electronic.com/app/purchase-order/PO-DE-22-02155) because of an error message.

Screenshot:
![sib](https://user-images.githubusercontent.com/86836253/189824860-52dfed1f-693e-40f8-a1f3-885f6851cc71.gif)

Fix: There is a new validation in erpnext v13 that won't allow if the default currency and the currency used is equal to 1. Which in this case the EUR and USD where there are times these two are equal.

Screenshot:
![sia](https://user-images.githubusercontent.com/86836253/189825072-31282adf-deea-495e-85ca-82dbf9a39314.gif)
