### PR TITLE
Fix(BOM)missing "/" in link when creating alternative items

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -773,7 +773,7 @@ cur_frm.select_bomline_alternate_items = function(opts) {
 		var selected_items = []
 		cur_frm.alt_list_data.forEach(function(item) {
 		  selected_items.push(
-			  '<a target="_blank" href="/app/item' + item.alt_item +'">' + item.alt_item + '</a> ' + `(${item.qty})`
+			  '<a target="_blank" href="/app/item/' + item.alt_item +'">' + item.alt_item + '</a> ' + `(${item.qty})`
 		  )
 		});
 		frappe.model.set_value('BOM Item', cdn, 'selected_alt_items', selected_items.join());


### PR DESCRIPTION
re : https://app.asana.com/0/1202488269220482/1203003479717830

Created as a sub issue. 

Issue: incorrect links for alternative items

Fix:
![BOM alternative item links](https://user-images.githubusercontent.com/85614308/191197353-5d11128a-0e94-48ad-802f-31478595b09f.gif)
