### PR TITLE
fix(po.json): make nonmandatory the supplier part number

### DIFF
--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -122,8 +122,7 @@
    "fieldname": "supplier_part_no",
    "fieldtype": "Data",
    "label": "Supplier Part Number",
-   "print_hide": 1,
-   "reqd": 1
+   "print_hide": 1
   },
   {
    "fieldname": "item_name",
@@ -851,7 +850,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-09-27 19:27:34.956212",
+ "modified": "2022-09-28 08:10:52.090850",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",


### PR DESCRIPTION
Making the supplier part nonmandatory cos it causes an error to the functions that create PO or add items in PO