### PR TITLE
feat(request_for_quotation.py): commented the code for creating user for supplier

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -102,13 +102,16 @@ class RequestforQuotation(BuyingController):
 				self.validate_email_id(rfq_supplier)
 
 				# make new user if required
-				update_password_link, contact = self.update_supplier_contact(rfq_supplier, self.get_link())
+				""" commented the code for creating user on creation of request for quotation
+					as discussed in MS Teams it is not required to create account for suppliers
+				"""
+				# update_password_link, contact = self.update_supplier_contact(rfq_supplier, self.get_link())
 
 				self.update_supplier_part_no(rfq_supplier.supplier)
-				self.supplier_rfq_mail(rfq_supplier, update_password_link, self.get_link())
+				# self.supplier_rfq_mail(rfq_supplier, update_password_link, self.get_link())
 				rfq_supplier.email_sent = 1
-				if not rfq_supplier.contact:
-					rfq_supplier.contact = contact
+				# if not rfq_supplier.contact:
+				# 	rfq_supplier.contact = contact
 				rfq_supplier.save()
 
 	def get_link(self):


### PR DESCRIPTION
Upon submitting a request for quotation, an error occur see screenshot below
![image](https://user-images.githubusercontent.com/40702858/193289008-f5be7551-b6f2-462a-9323-e0f2ed364f60.png)

Upon investigation, it is because of missing gender in creating user for supplier but as discussed in MS Teams, to comment the code for creating user for supplier in creating request for quotation
![Peek 2022-09-30 22-16](https://user-images.githubusercontent.com/40702858/193289741-1f161120-0af5-457d-9bed-17edcf7afc5b.gif)

