### PR TITLE
feat(sales_order.py): Do not set T&C when creating sales invoice from…

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -796,6 +796,11 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
 		if target.company_address:
 			target.update(get_fetch_values("Sales Invoice", "company_address", target.company_address))
 
+		#set terms and condition to blank
+		if target.tc_name:
+			target.tc_name = ''
+			target.terms = ''
+
 		# set the redeem loyalty points if provided via shopping cart
 		if source.loyalty_points and source.order_type == "Shopping Cart":
 			target.redeem_loyalty_points = 1


### PR DESCRIPTION
Asana Link: https://app.asana.com/0/1202487840949173/1202776279232143/f

Issue:
When creating a Sales Invoice directly from a Sales Order, the 'Terms and Conditions' section (or the tc_name field) should not be populated 

Fix:
Add Logic in core during creation of sales invoice through sales order

Screenshot:
Before:
![create sales invoice before](https://user-images.githubusercontent.com/86836253/195760485-f2eec02d-912a-49c6-a18f-1a5deaf2a015.gif)

After:
![create sales invoice after](https://user-images.githubusercontent.com/86836253/195760504-1b76637c-2ada-4841-93a2-84885e0f8e7d.gif)
