### PR TITLE
fix(leave allocation)set carry_forward and unused_leaves to allowed_on_submit

### DIFF
--- a/erpnext/hr/doctype/leave_allocation/leave_allocation.json
+++ b/erpnext/hr/doctype/leave_allocation/leave_allocation.json
@@ -117,12 +117,14 @@
    "label": "New Leaves Allocated"
   },
   {
+   "allow_on_submit": 1,
    "default": "0",
    "fieldname": "carry_forward",
    "fieldtype": "Check",
    "label": "Add unused leaves from previous allocations"
   },
   {
+   "allow_on_submit": 1,
    "depends_on": "carry_forward",
    "fieldname": "unused_leaves",
    "fieldtype": "Float",
@@ -237,7 +239,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-04-07 09:50:33.145825",
+ "modified": "2022-10-20 07:58:10.186885",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Allocation",


### PR DESCRIPTION
re : https://app.asana.com/0/1202488269220482/1203175074079541

Request: Set field properties for carry_foward and unsused leaves to be allowed_on_submit

Fix:
--
![Leave allocation allowed on submit](https://user-images.githubusercontent.com/85614308/196868628-0c6fbae8-333b-4e43-a614-7c6a710a9e20.gif)
