### PR TITLE
fix(leave_ledger_entry.json)set allow_on_submit property leave field

### DIFF
--- a/erpnext/hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+++ b/erpnext/hr/doctype/leave_ledger_entry/leave_ledger_entry.json
@@ -66,6 +66,7 @@
    "options": "transaction_type"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "leaves",
    "fieldtype": "Float",
    "in_list_view": 1,
@@ -123,7 +124,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-01-04 18:47:45.146652",
+ "modified": "2022-10-26 06:04:44.665033",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Ledger Entry",


### PR DESCRIPTION
re : https://app.asana.com/0/1202488269220482/1203175074079541

Issue noticed when testing:
https://github.com/elexess/eso-erpnext/pull/183

When ticking the "add unused leaves..." it saves successfully. But when reverting it back to unchecked, it throws the not allowed on submit error. 

Error:

![Error](https://user-images.githubusercontent.com/85614308/197933583-32fbe9ff-053c-4147-86c1-ff68995b1440.gif)

This is because there's another field in a different doctype (Leave Ledger Entry) being changed.

Fix: set the property of that field (leave) to be allowed on submit.
--
![Fix leave allocation](https://user-images.githubusercontent.com/85614308/197933737-60e175bc-2ef2-43d5-bd09-234459d73118.gif)

