### PR TITLE
fix(work_order.js): duplicate alternative items when switching

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -547,6 +547,8 @@ cur_frm.select_workline_alternate_item = function(opts) {
 			if (current_item_selection_idx != -1) {
 				cur_frm.alt_list_data.splice(current_item_selection_idx, 1)
 			}
+
+			cur_frm.alt_list_data = [...new Map(cur_frm.alt_list_data.reverse().map((m) => [m.alt_item, m])).values()];
 			cur_frm.render_alts_items(d, headers, cur_frm.alt_list_data)
 		}
 	})


### PR DESCRIPTION
Ref: https://app.asana.com/0/1202487840949165/1203503802585335/f

Issue: 
Some alternative items in Work Order show duplicate item when switching. 
<img width="1019" alt="image" src="https://user-images.githubusercontent.com/36461178/206126498-4b8432e2-7383-40d7-bd94-bbf30a145375.png">

Solution: 
Filter duplicates with same alt item then remove. 
![alt-item_dup](https://user-images.githubusercontent.com/36461178/206129110-01b9ab63-fd92-4113-a65a-59ae8173cb5b.gif)
