### PR TITLE
fix(stock_controller): allow expired batches for Material Transfers with PCB item groups

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -101,6 +101,9 @@ class StockController(AccountsController):
 			if is_material_issue:
 				continue
 
+			if self.purpose == "Material Transfer" and d.item_group in ["PCB (Leiterplatten)", "PCB (Leiterplatten) Customer Provided"]:
+				continue
+
 			if flt(d.qty) > 0.0 and d.get("batch_no") and self.get("posting_date") and self.docstatus < 2:
 				expiry_date = frappe.get_cached_value("Batch", d.get("batch_no"), "expiry_date")
 


### PR DESCRIPTION
Reference [Asana Link](https://app.asana.com/0/1202487840949165/1203578072994970/f)
 
**Solution:** Allow Material Transfers with Expired Batches for Items that belong to PCB (Leiterplatten) and PCB (Leiterplatten) - Customer provided for scrapping purposes.

See attached video below as a reference:


https://user-images.githubusercontent.com/58759735/208585210-a6d40229-2723-46ab-a915-a366efdeec41.mp4

