### PR TITLE
chore(work_order.js)remove core close button

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -615,23 +615,6 @@ erpnext.work_order = {
 	set_custom_buttons: function(frm) {
 		var doc = frm.doc;
 		if (doc.docstatus === 1 && doc.status != "Closed") {
-			frm.add_custom_button(__('Close'), function() {
-				frappe.confirm(__("Once the Work Order is Closed. It can't be resumed."),
-					() => {
-						erpnext.work_order.change_work_order_status(frm, "Closed");
-					}
-				);
-			}, __("Status"));
-
-			if (doc.status != 'Stopped' && doc.status != 'Completed') {
-				frm.add_custom_button(__('Stop'), function() {
-					erpnext.work_order.change_work_order_status(frm, "Stopped");
-				}, __("Status"));
-			} else if (doc.status == 'Stopped') {
-				frm.add_custom_button(__('Re-open'), function() {
-					erpnext.work_order.change_work_order_status(frm, "Resumed");
-				}, __("Status"));
-			}
 
 			const show_start_btn = (frm.doc.skip_transfer
 				|| frm.doc.transfer_material_against == 'Job Card') ? 0 : 1;


### PR DESCRIPTION
Ref : https://app.asana.com/0/1202488269220482/1203819087538970

remove core close buttons in work order doctype.

before:
<img width="1292" alt="image" src="https://user-images.githubusercontent.com/85614308/215026713-3e67ce53-b33c-48a8-b327-5ee10370b54f.png">

after:
<img width="1185" alt="image" src="https://user-images.githubusercontent.com/85614308/215026747-ad1def0d-fa7c-4418-b134-e24e70f7684b.png">
