### PR TITLE
feat(hooks.py): comment cruns update_youtube_data, rename_gle_sle_doc, reorder_item

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -454,18 +454,19 @@ scheduler_events = {
 	"cron": {
 		"0/5 * * * *": [
 			"erpnext.manufacturing.doctype.bom_update_log.bom_update_log.resume_bom_cost_update_jobs",
-		],
-		"0/30 * * * *": [
-			"erpnext.utilities.doctype.video.video.update_youtube_data",
-		],
+		]
+        # Commenting jobs belong since we are not using them in eso 
+		# "0/30 * * * *": [
+		# 	"erpnext.utilities.doctype.video.video.update_youtube_data",
+		# ],
 		# Hourly but offset by 30 minutes
-		"30 * * * *": [
-			"erpnext.accounts.doctype.gl_entry.gl_entry.rename_gle_sle_docs",
-		],
+		# "30 * * * *": [
+		# 	"erpnext.accounts.doctype.gl_entry.gl_entry.rename_gle_sle_docs",
+		# ],
 		# Daily but offset by 45 minutes
-		"45 0 * * *": [
-			"erpnext.stock.reorder_item.reorder_item",
-		],
+		# "45 0 * * *": [
+		# 	"erpnext.stock.reorder_item.reorder_item",
+		# ],
 	},
 	"all": [
 		"erpnext.projects.doctype.project.project.project_status_update_reminder",


### PR DESCRIPTION
Remove scheduled events in ERPNext hooks that rename both `GLE` and `SLE` we will be using instead the hash name that being set automatically when we create GLE and SLE.

This will solve the Lock wait Timeout we are encountering.
- **How does it resolve the issue:**
    - Bulk-updating existing transactions especially for GL Entries and SL Entries can be a heavy operation.
    - So, instead of waiting every 30 minutes to update all created Stock Entries to their related GL entries and SL entries, the updated naming will allow us to directly connect the transactions to each other.
    - Thus, this will also reduce the overall update time required in renaming the connected GL Entries and SL Entries to the Stock Entry, which is currently scheduled every 30 minutes. 

