### PR TITLE
fix(leave_application.py) remove is_lwp condition

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application.py
+++ b/erpnext/hr/doctype/leave_application/leave_application.py
@@ -778,7 +778,8 @@ def get_leave_details(employee, date):
 		}
 
 	# is used in set query
-	lwp = frappe.get_list("Leave Type", filters={"is_lwp": 1}, pluck="name")
+	# removed is_lwp=1 filter to show all Leave Types
+	lwp = frappe.get_list("Leave Type", filters={}, pluck="name")
 
 	return {
 		"leave_allocation": leave_allocation,


### PR DESCRIPTION
### Show "Krankenstand" in Leave Type Dropdown
-----

Reference: [Asana Link](https://app.asana.com/0/1202487840949165/1204175061824967/f)
**Solution:** Removed filter for Leave Type Field to show all Leave Types
 
Attached image as a sample:
![image](https://user-images.githubusercontent.com/58759735/225531661-4d12251e-13f2-44a8-ad03-7de9cbc6c899.png)

