### PR TITLE
fix(utils.js): Update Items btn dialog variable assignment

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -519,7 +519,7 @@ erpnext.utils.update_child_items = function(opts) {
 		})
 	}
 
-	new frappe.ui.Dialog({
+	const dialog = new frappe.ui.Dialog({
 		title: __("Update Items"),
 		fields: [
 			{


### PR DESCRIPTION
Asana: https://app.asana.com/0/1202487840949165/1204201602052788/f

Issue:
Update Items button in Purchase Order is not clickable because of the `ReferenceError: dialog is not defined` 

Solution:
Declare `dialog` variable.

Result: 
![updateitemsbtn](https://user-images.githubusercontent.com/36461178/226241989-4f042632-2e9f-4c59-a6a4-068bda6d6357.gif)
