### PR TITLE
fix(leave_application.py):fix incorrect available leaves being displayed

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application.py
+++ b/erpnext/hr/doctype/leave_application/leave_application.py
@@ -860,6 +860,7 @@ def get_leave_allocation_records(employee, date, leave_type=None):
 		)
 		.where(
 			(Ledger.from_date <= date)
+			& (Ledger.to_date >= date)
 			& (Ledger.docstatus == 1)
 			& (Ledger.transaction_type == "Leave Allocation")
 			& (Ledger.employee == employee)


### PR DESCRIPTION
ref : https://app.asana.com/0/1202488269220482/1204257506305355

Issue: Incorrect allocated leaves being displayed when creating a leave application. ERPNEXT core added changes in the script that considers "expired leaves" so it considers the leaves from previous years. In this case ESO doesn't have "expired_leaves" so we will be reverting their code changes.

Fix:
**from reported user leave application**
![image](https://user-images.githubusercontent.com/85614308/228140454-33361b52-2b37-4200-adfd-332f262c69d3.png)
