### PR TITLE
fix(work_order.js): Add Material Consumption Button to Create Group

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -669,8 +669,7 @@ erpnext.work_order = {
 							var consumption_btn = frm.add_custom_button(__('Material Consumption'), function() {
 								const backflush_raw_materials_based_on = frm.doc.__onload.backflush_raw_materials_based_on;
 								erpnext.work_order.make_consumption_se(frm, backflush_raw_materials_based_on);
-							});
-							consumption_btn.addClass('btn-primary');
+							}, __("Create"));
 						}
 					}
 				}


### PR DESCRIPTION
Asana Link: https://app.asana.com/0/1202487840949165/1204528939880890/f

Problem: Users often cannot see the workflow state when in the work order. 

Solution: Add Material Consumption Button to Create Group

Screenshot:

Before:
![Before](https://user-images.githubusercontent.com/86836253/236160508-5bc9afe6-f311-47f4-ab37-53bbefa08855.png)


After:
![After](https://user-images.githubusercontent.com/86836253/236160539-e0b651b5-a168-4bda-a140-149c5ee04277.jpg)
