### PR TITLE
fix(accounts_controller): attributeerror transaction date

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2334,6 +2334,9 @@ def get_supplier_block_status(party_name):
 
 
 def set_child_tax_template_and_map(item, child_item, parent_doc):
+	if parent_doc.doctype == 'Delivery Note':
+		parent_doc.transaction_date = parent_doc.posting_date
+		
 	args = {
 		"item_code": item.item_code,
 		"posting_date": parent_doc.transaction_date,


### PR DESCRIPTION
Ref: https://github.com/elexess/erp-shipment/pull/145#issuecomment-1678673118

Error: 
<img width="808" alt="image" src="https://github.com/elexess/eso-erpnext/assets/36461178/d74eb3db-f31a-4d74-a75d-62ffba5bb1d7">

Fix: 
Delivery note uses the posting date instead of transaction date. With this, set a value for the transaction date with posting date only for Delivery Note doctype