### PR TITLE
feat(sales_order.py): update header delivery date based on min date of list

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -142,11 +142,11 @@ class SalesOrder(SellingController):
 	def validate_delivery_date(self):
 		if self.order_type == "Sales" and not self.skip_delivery_note:
 			delivery_date_list = [d.delivery_date for d in self.get("items") if d.delivery_date]
-			max_delivery_date = max(delivery_date_list) if delivery_date_list else None
-			if (max_delivery_date and not self.delivery_date) or (
-				max_delivery_date and getdate(self.delivery_date) != getdate(max_delivery_date)
+			min_delivery_date = min(delivery_date_list) if delivery_date_list else None
+			if (min_delivery_date and not self.delivery_date) or (
+				min_delivery_date and getdate(self.delivery_date) != getdate(min_delivery_date)
 			):
-				self.delivery_date = max_delivery_date
+				self.delivery_date = min_delivery_date
 			if self.delivery_date:
 				for d in self.get("items"):
 					if not d.delivery_date:


### PR DESCRIPTION
## Asana Task
[Sales Order: Update header delivery_date based on min date of list](https://app.asana.com/0/1202487840949173/1206874642873936/f)

## Background of the Request
> For [SO-DE-24-00213](https://erp.eso-electronic.com/app/sales-order/SO-DE-24-00213), I need to deliver pos. 1 and 2 on April 18th, Positon 3 needs to be delivered on May 10th. Unfortunately the system will only take one of the two dates, it is not possible to add 2 different delivery dates in one SO.

Upon further investigation by Shiela and Sarrah, it was found that when the child table's Delivery Date is updated, it will also update the header's delivery_date value to the max date of the table due to the logic of the core function [validate_delivery_date](https://github.com/newmatik/eso-erpnext/blob/721a5c7d305b166df0d59d6330e7037638212c9e/erpnext/selling/doctype/sales_order/sales_order.py#L142)

Unfortunately, this default behaviour of ERPNext does not coincide with Newmatik's internal processes because the outgoing team will always work with the delivery date of the header. Thus, the Business Manager requested that the ideal date that should be set for the header is the earliest (or min) date of the table, instead of the max date.

## Local Tests

1. When the header delivery_date is updated, the child table's delivery dates are updated to follow the header date = Passed
![image](https://github.com/newmatik/eso-erpnext/assets/35899441/315fdd43-19f6-420a-b2f7-cdfa2092a7ee)

2. When the child table's delivery dates are updated, the header date should be updated to the earliest (or min) date of the table = Passed

https://github.com/newmatik/eso-erpnext/assets/35899441/c5121f5f-7af8-4e54-a06f-fb2ea4a6f4d0