### PR TITLE
fix(pending_so_items_for_purchase_request.py): add discontinued to ex…

### DIFF
--- a/erpnext/selling/report/pending_so_items_for_purchase_request/pending_so_items_for_purchase_request.py
+++ b/erpnext/selling/report/pending_so_items_for_purchase_request/pending_so_items_for_purchase_request.py
@@ -65,7 +65,7 @@ def get_data():
 		WHERE
 			so.docstatus = 1
 			and so.name = so_item.parent
-			and so.status not in  ("Closed","Completed","Cancelled")
+			and so.status not in  ("Closed","Completed","Cancelled","Discontinued")
 		GROUP BY
 			so.name,so_item.item_code
 		""",


### PR DESCRIPTION
…cluded status

Related to https://github.com/newmatik/eso-newmatik/pull/6332

Updated the pending_so_items_for_purchase_request.py report because it uses the Sales Order status field. This is to also exclude "Discontinued" SOs from the dataset.