### PR TITLE
fix(utils): update Items dialog to respect rate field precision

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -493,6 +493,20 @@ erpnext.utils.update_child_items = function(opts) {
 		in_list_view: 1,
 		label: __('Rate')
 	}];
+
+	// Inherit rate precision from the child doctype's field definition so
+	// property-setter overrides (e.g. 5 decimal places) are respected.
+	var child_dt_meta = frappe.get_meta(frm.doc.doctype);
+	var child_table_df = child_dt_meta && (child_dt_meta.fields || []).find(function(f) {
+		return f.fieldname === child_docname;
+	});
+	if (child_table_df && child_table_df.options) {
+		var rate_df = frappe.meta.get_docfield(child_table_df.options, "rate");
+		if (rate_df && rate_df.precision) {
+			fields.find(function(f) { return f.fieldname === "rate"; }).precision = cint(rate_df.precision);
+		}
+	}
+
     if (frm.doc.doctype == "Delivery Note") {
         fields.splice(2, 0, {
             fieldtype: 'Float',


### PR DESCRIPTION
RE: https://github.com/newmatik/eso-newmatik/pull/6811
Apply same precision increase to the "Update Items" modal.
- Note: Unfortunately, this only works if the change is done via the eso-erpnext repository. I tried asking Opus to make the changes in Newmatik, but it is much more complicated and does not 100% work all the time.

<img width="1530" height="931" alt="image" src="https://github.com/user-attachments/assets/50d0a71e-76c5-4f9e-a552-184fb4718cd0" />


## AI Summary

The "Update Items" dialog on submitted documents (Purchase Order, Sales Order, etc.) hardcodes the rate field as a `Currency` type without specifying precision. This causes `ControlCurrency.get_precision()` to fall back to the system's `currency_precision` default, ignoring any property setter overrides on the child doctype's rate field.

For example, if Purchase Order Item's rate is configured with 5 decimal places via a property setter, entering `1.12345` through the Update Items dialog would silently round it to `1.1235`(4 decimals from the system default).

The fix reads the precision from the child doctype's rate field metadata (which includes property setter overrides) and applies it to the dialog's rate field definition before the dialog is created.